### PR TITLE
fix: align cert provisioning to the new endpoint

### DIFF
--- a/client/project.go
+++ b/client/project.go
@@ -360,8 +360,24 @@ func (c *Client) VerifyDomain(projectID, domainName string) error {
 	return c.request("POST", path, nil, nil, nil)
 }
 
-// ProvisionCertificate creates a valid TLS certificate for a custom domain name.
-func (c *Client) ProvisionCertificate(projectID, domainName string) error {
+// ProvisionCertificateAutomatic automatically provisions a valid TLS
+// certificate for a custom domain name.
+func (c *Client) ProvisionCertificateAutomatic(projectID, domainName string) error {
 	path := fmt.Sprintf("/api/projects/%s/domains/%s/certificates", projectID, domainName)
-	return c.request("POST", path, nil, nil, nil)
+	bs, err := json.Marshal(map[string]string{"strategy": "automatic"})
+	if err != nil {
+		return err
+	}
+	return c.request("POST", path, nil, bytes.NewBuffer(bs), nil)
+}
+
+// ProvisionCertificateManual adds a custom TLS certificate for a custom domain
+// name.
+func (c *Client) ProvisionCertificateManual(projectID, domainName string, certificateChain string, privateKey string) error {
+	path := fmt.Sprintf("/api/projects/%s/domains/%s/certificates", projectID, domainName)
+	bs, err := json.Marshal(map[string]string{"strategy": "manual", "certificateChain": certificateChain, "privateKey": privateKey})
+	if err != nil {
+		return err
+	}
+	return c.request("POST", path, nil, bytes.NewBuffer(bs), nil)
 }

--- a/deploy/resource_custom_domain_validation.go
+++ b/deploy/resource_custom_domain_validation.go
@@ -41,7 +41,7 @@ func createCustomDomainValidation(d *schema.ResourceData, meta interface{}) erro
 		return err
 	}
 
-	if err := c.ProvisionCertificate(projectID, domainName); err != nil {
+	if err := c.ProvisionCertificateAutomatic(projectID, domainName); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
This commit fixes certificate provisioning to use the new
certificate provisioning endpoint. It also adds support for manual
certificates in the client, but not yet in the provider.
