### PR TITLE
add default env var value for api token

### DIFF
--- a/deploy/provider.go
+++ b/deploy/provider.go
@@ -16,6 +16,7 @@ func Provider() *schema.Provider {
 			"api_token": {
 				Type:        schema.TypeString,
 				Required:    true,
+				DefaultFunc: schema.EnvDefaultFunc("DEPLOY_TOKEN", nil),
 				Description: "API Token used for accessing Deno Deploy",
 			},
 		},


### PR DESCRIPTION
This makes it both easier to use the provider in CI but also enables
easier testing -- the convention I've seen seems to be to set the
provider configurations variables as environment variables in a makefile
to run the acceptance tests.