### PR TITLE
fix github link on new project

### DIFF
--- a/deploy/resource_project.go
+++ b/deploy/resource_project.go
@@ -202,7 +202,7 @@ func createProject(d *schema.ResourceData, meta interface{}) error {
 		ghLinkList := gh.([]interface{})
 		ghLink := ghLinkList[0].(map[string]interface{})
 		if _, err := c.LinkProject(client.LinkProjectRequest{
-			ProjectID:    d.Id(),
+			ProjectID:    project.ID,
 			Organization: ghLink["organization"].(string),
 			Repo:         ghLink["repo"].(string),
 			Entrypoint:   ghLink["entrypoint"].(string),


### PR DESCRIPTION
Fixes #14. In the create hook of the `deploy_project` resource, use the
body of the response for `POST /api/projects` instead of the Terraform
resource ID to do the github link action since the Terraform resource ID
isn't set at that point, causing the operation to crash.